### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SDK nainstalujete standardním příkazem:
 	
 	pod install govdata
 
-Pro správnou funkci statické knihovny je potřebná správná konfigurace `XCode` projektu pro `Cocoapods` včetně správných cest ke hlavičkovým souborům a konfigurace build Targets. Knihovna je pokryta automatizovanými testy.
+Pro správnou funkci statické knihovny je potřebná správná konfigurace `XCode` projektu pro `CocoaPods` včetně správných cest ke hlavičkovým souborům a konfigurace build Targets. Knihovna je pokryta automatizovanými testy.
 
 Jedinou závislostí SDK je síťová knihovna `AFNetworking`.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
