### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SDK nainstalujete standardním příkazem:
 	
 	pod install govdata
 
-Pro správnou funkci statické knihovny je potřebná správná konfigurace `XCode` projektu pro `CocoaPods` včetně správných cest ke hlavičkovým souborům a konfigurace build Targets. Knihovna je pokryta automatizovanými testy.
+Pro správnou funkci statické knihovny je potřebná správná konfigurace `Xcode` projektu pro `CocoaPods` včetně správných cest ke hlavičkovým souborům a konfigurace build Targets. Knihovna je pokryta automatizovanými testy.
 
 Jedinou závislostí SDK je síťová knihovna `AFNetworking`.
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
